### PR TITLE
Use new ParticleStatus enum to handle the status for ParticleGroup 

### DIFF
--- a/distgen/beam.py
+++ b/distgen/beam.py
@@ -1,3 +1,4 @@
+from pmd_beamphysics import ParticleStatus
 import numpy as np
 from .physical_constants import unit_registry, pi, MC2
 import functools
@@ -265,13 +266,13 @@ class Beam():
             vprint(f'avg_{x} = {self.avg(x).to(unit):G~P}, sigma_{x} = {self.std(x).to(unit):G~P}', True, 1, True)
             
 
-    def data(self):
+    def data(self, status=ParticleStatus.ALIVE):
         """
         Converts to fixed units and returns a dict of data.
         
         See function Sbeam_data
         """
-        return beam_data(self)
+        return beam_data(self, status)
    
 '''
 class Beam_old():
@@ -568,7 +569,7 @@ def beam_data_old(beam):
     return data            
 '''
 
-def beam_data(beam):
+def beam_data(beam, status):
     """
     Converts all units to standard units and strips them as a data dict with:
         str: species
@@ -594,7 +595,7 @@ def beam_data(beam):
     weight = np.abs((beam['w'].magnitude) * total_charge) # Weight should be macrocharge in C
     
     # Status
-    status = np.full(n_particle, 1) # Status == 1 means live
+    status_array = np.full(n_particle, int(status)) # Status == 1 means live
     
     # standard units and types
     names = ['x', 'y', 'z', 'px',   'py',   'pz',   't']
@@ -603,7 +604,7 @@ def beam_data(beam):
     data = {'n_particle':n_particle,
             'species':species,
             'weight':weight,
-            'status':status
+            'status':status_array
     }
     
     for name, unit in zip(names, units):

--- a/distgen/generator.py
+++ b/distgen/generator.py
@@ -23,7 +23,7 @@ from .physical_constants import pi
 from .physical_constants import MC2
 from .physical_constants import unit_registry
 
-from pmd_beamphysics import ParticleGroup, pmd_init
+from pmd_beamphysics import ParticleGroup, ParticleStatus, pmd_init
 
 import warnings
 
@@ -410,7 +410,13 @@ class Generator(Base):
         an openPMD-beamphysics ParticleGroup in self.particles """
         if self.input is not None:
             beam = self.beam()
-            self.particles = ParticleGroup(data=beam.data())
+        
+            if self.params['start']['type'] == "cathode":
+                status = ParticleStatus.CATHODE
+            else:
+                status = ParticleStatus.ALIVE
+                
+            self.particles = ParticleGroup(data=beam.data(status=status))
             self.output = self.particles
             vprint(f'Created particles in .particles: \n   {self.particles}', self.verbose > 0, 1, False)
         else:


### PR DESCRIPTION
 Checks `self.params['start']['type'] == "cathode"` and sets all `status = ParticleStatus.CATHODE` form the latest openPMD-beamphysics Python package.