### PR TITLE
FIX: numpy 2.0 support, adding some pytest tests

### DIFF
--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -1,0 +1,23 @@
+name: "conda setup"
+description: "Prepare the conda environment"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Mambaforge
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-variant: Mambaforge
+        activate-environment: pydfcsr
+        use-mamba: true
+        channels: conda-forge
+    - name: Update environment
+      shell: bash -l {0}
+      run: mamba env update -n pydfcsr -f environment.yml
+    - name: Install our Python package
+      shell: bash -l {0}
+      run: |
+        pip install --no-dependencies .
+    - name: Show the installed packages
+      shell: bash -l {0}
+      run: |
+        conda list

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,12 +22,7 @@ jobs:
           mamba-version: "*"
           channels: conda-forge
           activate-environment: distgen
-          environment-file: environment.yml
-
-      - name: Install test requirements
-        shell: bash -l {0}
-        run: |
-          conda install pytest
+          environment-file: environment-dev.yml
 
       - name: Show conda environment packages
         shell: bash -l {0}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Run Tests
         shell: bash -l {0}
         run: |
-          pytest -v
+          pytest -v --cov=distgen/

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Test ${{ matrix.os }} (${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+          mamba-version: "*"
+          channels: conda-forge
+          activate-environment: distgen
+          environment-file: environment.yml
+
+      - name: Install test requirements
+        shell: bash -l {0}
+        run: |
+          conda install pytest
+
+      - name: Show conda environment packages
+        shell: bash -l {0}
+        run: |
+          conda list
+
+      - name: Ensure importability
+        shell: bash -l {0}
+        run: |
+          cd /
+          python -c "import distgen"
+
+      - name: Run Tests
+        shell: bash -l {0}
+        run: |
+          pytest -v

--- a/distgen/archive.py
+++ b/distgen/archive.py
@@ -12,7 +12,7 @@ def fstr(s):
     """
     Makes a fixed string for h5 files
     """
-    return np.string_(s)
+    return np.bytes_(s)
 
 
 

--- a/distgen/dist.py
+++ b/distgen/dist.py
@@ -2785,12 +2785,12 @@ class SuperPosition2d(Dist2d):
                 if(dists[name].min_dx is not None):
                     min_dx = dists[name].min_dx
                 else:
-                    min_dx = np.Inf*xi.units
+                    min_dx = np.inf*xi.units
                     
                 if(dists[name].min_dy is not None):
                     min_dy = dists[name].min_dy
                 else:
-                    min_dy = np.Inf*yi.units
+                    min_dy = np.inf*yi.units
                 
             else:
                 
@@ -2871,12 +2871,12 @@ class Product2d(Dist2d):
                 if(dists[name].min_dx is not None):
                     min_dx = dists[name].min_dx
                 else:
-                    min_dx = np.Inf*xi.units
+                    min_dx = np.inf*xi.units
                     
                 if(dists[name].min_dy is not None):
                     min_dy = dists[name].min_dy
                 else:
-                    min_dy = np.Inf*yi.units
+                    min_dy = np.inf*yi.units
                 
             else:
                 

--- a/distgen/generator.py
+++ b/distgen/generator.py
@@ -319,8 +319,8 @@ class Generator(Base):
             g = h5py.File(h5, 'w')
             # Proper openPMD init
             pmd_init(g, basePath='/', particlesPath='particles/')
-            g.attrs['software'] = np.string_('distgen') # makes a fixed string
-            #TODO: add version: g.attrs('version') = np.string_(__version__)
+            g.attrs['software'] = np.bytes_('distgen') # makes a fixed string
+            #TODO: add version: g.attrs('version') = np.bytes_(__version__)
 
         else:
             g = h5

--- a/distgen/tests/conftest.py
+++ b/distgen/tests/conftest.py
@@ -1,0 +1,10 @@
+import pathlib
+
+TESTS_PATH = pathlib.Path(__file__).resolve().parent
+DISTGEN_PATH = TESTS_PATH.parent
+REPO_ROOT = DISTGEN_PATH.parent
+DOCS_PATH = REPO_ROOT / "docs"
+EXAMPLES_PATH = DOCS_PATH / "examples"
+EXAMPLES_DATA_PATH = EXAMPLES_PATH / "data"
+
+assert EXAMPLES_PATH.exists()

--- a/distgen/tests/test_beam.py
+++ b/distgen/tests/test_beam.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python
+import pathlib
+import numpy as np
+import pytest
+
+from distgen.beam import Beam
+from .. import Generator
+from ..physical_constants import PHYSICAL_CONSTANTS
+from ..tools import check_abs_and_rel_tols
+
+from .conftest import EXAMPLES_DATA_PATH
+
+coordinates = {
+    "x",
+    "y",
+    "z",
+    "px",
+    "py",
+    "pz",
+    "r",
+    "theta",
+    "pr",
+    "ptheta",
+    "xp",
+    "yp",
+    "thetax",
+    "thetay",
+    "gamma",
+    "energy",
+    "kinetic_energy",
+    "beta_x",
+    "beta_y",
+    "beta_z",
+}
+
+
+@pytest.fixture(params=list(EXAMPLES_DATA_PATH.glob("*.yaml")), scope="module")
+def yaml_file(request: pytest.FixtureRequest) -> pathlib.Path:
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def beam(yaml_file: pathlib.Path) -> Beam:
+    G = Generator(str(yaml_file), verbose=0)
+    G["n_particle"] = 10_000
+    return G.beam()
+
+
+def run_test_on_input_file(input_file, test):
+    G = Generator(input_file, verbose=0)
+    G["n_particle"] = 10_000
+    test(G.beam())
+
+
+# # Statistical Tests
+
+
+def test_weight_normalization(beam):
+    # $\sum_i w_i = 1$
+    check_abs_and_rel_tols(
+        "macroparticle weights", np.sum(beam["w"]), 1.0, abs_tol=1e-12, rel_tol=1e-15
+    )
+
+
+def test_avg(beam):
+    # $\langle \mathcal{O}\rangle = \sum_i w_i \mathcal{O}_i$
+
+    for var in coordinates:
+        avg_beam, avg_numpy = beam.avg(var), np.sum(beam["w"] * beam[var])
+        check_abs_and_rel_tols(
+            "beam.avg", avg_beam, avg_numpy, abs_tol=1e-12, rel_tol=1e-15
+        )
+
+
+def test_std(beam):
+    # $\sigma_{\mathcal{O}}^2 = \sum_i w_i (\mathcal{O}_i-\langle \mathcal{O}\rangle)^2 $
+
+    for var in coordinates:
+        sigma2_beam = beam.std(var) ** 2
+        sigma2_numpy = np.sum(beam["w"] * (beam[var] - beam.avg(var)) ** 2)
+        check_abs_and_rel_tols(
+            "beam.std", sigma2_beam, sigma2_numpy, abs_tol=1e-8, rel_tol=1e-15
+        )
+
+
+# # Cylindrical Coordinates
+# ---
+# # Getting
+
+
+def test_r(beam):
+    # $r=\sqrt{ x^2 + y^2 }$
+
+    check_abs_and_rel_tols(
+        "beam.r",
+        beam["r"],
+        np.sqrt(beam["x"] ** 2 + beam["y"] ** 2),
+        abs_tol=1e-15,
+        rel_tol=1e-15,
+    )
+
+
+def test_x(beam):
+    # $x=r\cos\theta$
+
+    check_abs_and_rel_tols(
+        "beam.x = r cos(theta)",
+        beam["x"],
+        beam["r"] * np.cos(beam["theta"]),
+        abs_tol=1e-12,
+        rel_tol=1e-11,
+    )
+
+
+def test_y(beam):
+    # $y = r\sin\theta$
+
+    check_abs_and_rel_tols(
+        "beam.y = r sin(theta)",
+        beam["y"],
+        beam["r"] * np.sin(beam["theta"]),
+        abs_tol=1e-12,
+        rel_tol=1e-11,
+    )
+
+
+def test_pr(beam):
+    # $p_r = p_x\cos\theta + p_y\sin\theta$
+
+    check_abs_and_rel_tols(
+        "beam.pr = px cos(theta) + py sin(theta)",
+        beam["pr"],
+        beam["px"] * np.cos(beam["theta"]) + beam["py"] * np.sin(beam["theta"]),
+        abs_tol=1e-12,
+        rel_tol=1e-15,
+    )
+
+
+def test_ptheta(beam):
+    # $p_{\theta} = -p_x\sin\theta + p_y\cos\theta$
+    check_abs_and_rel_tols(
+        "beam.ptheta = -px sin(theta) + py cos(theta)",
+        beam["ptheta"],
+        -beam["px"] * np.sin(beam["theta"]) + beam["py"] * np.cos(beam["theta"]),
+        abs_tol=1e-12,
+        rel_tol=1e-15,
+    )
+
+
+# # Transverse Derivatives and Angles
+
+
+def test_xp(beam):
+    # $x^{\prime} = p_x/p_z$
+
+    check_abs_and_rel_tols(
+        "beam.xp = px/pz",
+        beam["xp"],
+        beam["px"].to(beam["pz"].units) / beam["pz"],
+        abs_tol=1e-14,
+        rel_tol=1e-15,
+    )
+
+
+def test_yp(beam):
+    # $y^{\prime} = p_y/p_z$
+    check_abs_and_rel_tols(
+        "beam.yp = py/pz",
+        beam["yp"],
+        beam["py"].to(beam["pz"].units) / beam["pz"],
+        abs_tol=1e-14,
+        rel_tol=1e-15,
+    )
+
+
+def test_thetax(beam):
+    # $\theta_x = \arctan(p_x/p_z)$
+
+    check_abs_and_rel_tols(
+        "beam.thetax = arctan(px/pz)",
+        beam["thetax"],
+        np.arctan2(beam["px"].to(beam["pz"].units), beam["pz"]),
+        abs_tol=1e-15,
+        rel_tol=1e-15,
+    )
+
+
+def test_thetay(beam):
+    # $\theta_y = \arctan(p_y/p_z)$
+
+    check_abs_and_rel_tols(
+        "beam.thetay = arctan(py/pz)",
+        beam["thetay"],
+        np.arctan2(beam["py"].to(beam["pz"].units), beam["pz"]),
+        abs_tol=1e-15,
+        rel_tol=1e-15,
+    )
+
+
+# # Relativistic Quantities
+# ---
+
+
+def test_p(beam):
+    # $p=\sqrt{p_x^2 + p_y^2 + p_z^2}$
+
+    deviation = np.abs(
+        beam["p"] - np.sqrt(beam["px"] ** 2 + beam["py"] ** 2 + beam["pz"] ** 2)
+    )
+    check_abs_and_rel_tols(
+        "beam.p = sqrt(px^2 + py^2 + pz^2)",
+        beam["p"],
+        np.sqrt(beam["px"] ** 2 + beam["py"] ** 2 + beam["pz"] ** 2),
+        abs_tol=1e-15,
+        rel_tol=1e-15,
+    )
+
+
+def test_energy(beam):
+    # $E = \sqrt{c^2|\vec{p}|^2 + (mc^2)^2}$
+
+    c = PHYSICAL_CONSTANTS["speed of light in vacuum"]
+
+    check_abs_and_rel_tols(
+        "beam.energy = sqrt(c^2p^2 + (mc^2)^2)",
+        beam["energy"],
+        np.sqrt(c**2 * beam["p"] ** 2 + beam.mc2**2),
+        abs_tol=1e-9,
+        rel_tol=1e-15,
+    )
+
+
+def test_gamma(beam):
+    # $\gamma = \sqrt{1+\left(\frac{p}{mc}\right)^2}$, $E/mc^2$
+
+    mc = beam.species_mass * PHYSICAL_CONSTANTS["speed of light in vacuum"]
+
+    check_abs_and_rel_tols(
+        "beam.gamma = sqrt( 1 + (p/mc)^2 )",
+        beam["gamma"],
+        np.sqrt(1 + (beam["p"] / mc).to_reduced_units() ** 2),
+        abs_tol=1e-10,
+        rel_tol=1e-10,
+    )
+
+    check_abs_and_rel_tols(
+        "beam.gamma = E/mc^2",
+        beam["gamma"],
+        beam["energy"] / beam.mc2,
+        abs_tol=1e-15,
+        rel_tol=1e-15,
+    )
+
+
+def test_beta(beam):
+    # $\beta = \frac{c|\vec{p}|}{E}$
+
+    check_abs_and_rel_tols(
+        "beam.beta = c|p|/E",
+        beam["beta"],
+        PHYSICAL_CONSTANTS["speed of light in vacuum"] * beam.p / beam.energy,
+        abs_tol=1e-11,
+        rel_tol=1e-14,
+    )
+
+    assert max(beam["beta"]) < 1, "max(beta) > 1, faster than light particle!"
+
+
+def test_beta_xi(beam):
+    # $\beta_{x_i} = \frac{cp_{x_i}}{E}$, $\beta_x = x^{\prime}\beta_z$, $\beta_y = y^{\prime}\beta_z$,  $\beta_z = \frac{\beta}{\sqrt{1+(x^{\prime})^2 +(y^{\prime})^2}}$
+
+    for var in ["x", "y", "z"]:
+        check_abs_and_rel_tols(
+            "beam.beta_xi = c pxi/E )",
+            beam[f"beta_{var}"],
+            (
+                PHYSICAL_CONSTANTS["speed of light in vacuum"]
+                * beam[f"p{var}"]
+                / beam["energy"]
+            ).to_reduced_units(),
+            abs_tol=1e-15,
+            rel_tol=1e-15,
+        )
+
+        check_abs_and_rel_tols(
+            "beam.beta_z = sign(pz)*beta/sqrt( 1 + x'^2 + y'^2 )",
+            beam["beta_z"],
+            np.sign(beam["pz"])
+            * beam["beta"]
+            / np.sqrt(1 + beam["xp"] ** 2 + beam["yp"] ** 2),
+            abs_tol=1e-11,
+            rel_tol=5e-9,
+        )
+
+
+def test_kinetic_energy(beam):
+    # KE = $mc^2(\gamma-1)$, $E-mc^2$
+
+    if PHYSICAL_CONSTANTS.species(beam["species"])["mass"] > 0:
+        check_abs_and_rel_tols(
+            "beam.kinetic_energy = mc2*(gamma-1)",
+            beam["kinetic_energy"],
+            beam.mc2 * (beam["gamma"] - 1),
+            abs_tol=1e-9,
+            rel_tol=1e-05,
+        )
+
+    check_abs_and_rel_tols(
+        "beam.kinetic_energy = E - mc2",
+        beam["kinetic_energy"],
+        beam["energy"] - beam.mc2,
+        abs_tol=1e-15,
+        rel_tol=1e-15,
+    )
+
+
+# # Twiss Parameters
+# ---
+# # Getting
+#
+
+
+def test_emitt_normalized(beam):
+    # $\epsilon_{n,x_i} = \frac{1}{mc}\sqrt{\sigma_{x_i}^2\sigma_{p_{x_i}}^2 - \langle \left(x_i-\langle x_i\rangle\right)\left(p_{x_i}-\langle p_{x_i}\rangle\right)\rangle^2 }$
+
+    for var in ["x", "y"]:
+        mc = beam.species_mass * PHYSICAL_CONSTANTS["speed of light in vacuum"]
+
+        stdx = beam.std(var)
+        stdp = (beam.std(f"p{var}") / mc).to_reduced_units()
+        dx = beam[var] - beam.avg(var)
+        dp = ((beam[f"p{var}"] - beam.avg(f"p{var}")) / mc).to_reduced_units()
+
+        check_abs_and_rel_tols(
+            "beam.emitt (normalized)",
+            beam.emitt(var),
+            np.sqrt(stdx**2 * stdp**2 - (np.sum(beam["w"] * dx * dp)) ** 2),
+            abs_tol=1e-11,
+            rel_tol=1e-11,
+        )
+
+
+def test_emitt_geometric(beam):
+    # $\epsilon_{x} = \sqrt{\sigma_x^2\sigma_{x^{\prime}}^2 - \langle \left(x-\langle x\rangle\right)\left(x^{\prime}-\langle x^{\prime}\rangle\right)\rangle^2 }$
+
+    for var in ["x", "y"]:
+        stdx = beam.std(var)
+        stdp = beam.std(f"{var}p")
+        dx = beam[var] - beam.avg(var)
+        dp = beam[f"{var}p"] - beam.avg(f"{var}p")
+
+        check_abs_and_rel_tols(
+            "beam.emitt (geometric)",
+            beam.emitt(var, "geometric"),
+            np.sqrt(stdx**2 * stdp**2 - (np.sum(beam["w"] * dx * dp)) ** 2),
+            abs_tol=1e-14,
+            rel_tol=1e-15,
+        )
+
+
+def twiss_beta_xi(beam):
+    # Twiss $\beta_{x_i} = \frac{\sigma_x^2}{\epsilon_x}$
+
+    for var in ["x", "y"]:
+        stdx = beam.std(var)
+        epsx = beam.emitt(var, "geometric")
+
+        if epsx > 0:
+            check_abs_and_rel_tols(
+                "beam.Beta_xi (Twiss)",
+                beam.Beta(var),
+                stdx**2 / epsx,
+                abs_tol=1e-14,
+                rel_tol=1e-15,
+            )
+
+
+def test_alpha_xi(beam):
+    # Twiss $\alpha_{x_i} = -\frac{\langle(x-\langle x\rangle)(x^{\prime}-\langle x^{\prime}\rangle)\rangle}{\epsilon_x}$
+
+    for var in ["x", "y"]:
+        dx = beam[var] - beam.avg(var)
+        dp = beam[f"{var}p"] - beam.avg(f"{var}p")
+        epsx = beam.emitt(var, "geometric")
+
+        if epsx > 0:
+            check_abs_and_rel_tols(
+                "beam.Alpha_xi (Twiss)",
+                beam.Alpha(var),
+                -sum(beam["w"] * dx * dp) / epsx,
+                abs_tol=1e-14,
+                rel_tol=1e-14,
+            )
+
+
+def test_gamma_xi(beam):
+    # Twiss $\gamma_{x_i} = \frac{\sigma_{x^{\prime}}^2}{\epsilon_x}$
+    for var in ["x", "y"]:
+        stdp = beam.std(f"{var}p")
+        epsx = beam.emitt(var, "geometric")
+
+        if epsx > 0:
+            check_abs_and_rel_tols(
+                "beam.Gamma_xi (Twiss)",
+                beam.Gamma(var),
+                stdp**2 / epsx,
+                abs_tol=1e-14,
+                rel_tol=1e-14,
+            )

--- a/distgen/tests/test_beam.py
+++ b/distgen/tests/test_beam.py
@@ -33,8 +33,10 @@ coordinates = {
     "beta_z",
 }
 
+yaml_files = list(EXAMPLES_DATA_PATH.glob("*.yaml"))
 
-@pytest.fixture(params=list(EXAMPLES_DATA_PATH.glob("*.yaml")), scope="module")
+
+@pytest.fixture(params=yaml_files, ids=[fn.name for fn in yaml_files], scope="module")
 def yaml_file(request: pytest.FixtureRequest) -> pathlib.Path:
     return request.param
 

--- a/distgen/tests/test_dist.py
+++ b/distgen/tests/test_dist.py
@@ -1,0 +1,541 @@
+#!/usr/bin/env python
+
+from distgen.physical_constants import unit_registry
+import numpy as np
+from matplotlib import pyplot as plt
+
+from distgen.tests.conftest import EXAMPLES_DATA_PATH
+
+
+def test_rng_1():
+    # Random Number Generation
+    # ---
+
+    # To sample various distributions requires generating random numbers and
+    # supplying them to the $CDF^{-1}$ functions for each corresponding
+    # distribution.  Currently, this is handled using
+    #
+    # `distgen.dist.random_generator(shape, sequence, **params)`.
+    #
+    # Here `shape = (n_dimension, n_particle)` determines the shape of the
+    # random numbers returned.  The keyword 'sequence' can be used to set the
+    # sequence to Hammerlsey for quasi-random numbers.
+    #
+    # The difference is shown below:
+
+    from distgen.dist import random_generator
+
+    shape = (2, 100)
+
+    p1 = random_generator(shape, "hammersley")
+    p2 = random_generator(shape, "pseudo")
+
+    fig, ax = plt.subplots(1, 2, constrained_layout=True)
+
+    ax[0].plot(p1[0, :], p1[1, :], ".")
+    ax[0].set(xlabel="rx", ylabel="ry", title="hammersley")
+    ax[1].plot(p2[0, :], p2[1, :], "*")
+    ax[1].set(xlabel="rx", ylabel="ry", title="random.rand")
+
+
+def test_rng_seed():
+    from distgen.dist import random_generator
+    # When using pseudo random numbers via NumPy, it is possible to set the generator seed:
+
+    shape = (2, 100)
+    fig, ax = plt.subplots(1, 1, constrained_layout=True)
+
+    p2 = random_generator(shape, "pseudo", seed=0)
+    p3 = random_generator(shape, "pseudo", seed=0)
+
+    ax.plot(p2[0, :], p2[1, :], "*")
+    ax.plot(p3[0, :], p3[1, :], ".")
+    ax.set(xlabel="rx", ylabel="ry", title="random.rand")
+
+
+def test_generator():
+    from distgen import Generator
+
+    gen = Generator(str(EXAMPLES_DATA_PATH / "jpeg.image.in.yaml"), verbose=0)
+    gen.input
+
+    gen.run().plot("x", "y")
+
+    inputs = gen.input.copy()
+    inputs["random"] = {"type": "pseudo", "seed": 0}
+
+    gen = Generator(inputs, verbose=0)
+    gen.run().plot("x", "y")
+
+
+def test_1d_distributions():
+    # Distgen supports several one dimensional distribution types.
+    #
+    # # Uniform 1D
+    #
+    # The uniform distirbuition is defined by a probability distribution function:
+    #
+    # $\rho(x) = \frac{1}{b-a}$ for $a\leq x\leq b$ and zero elsewhere.
+    #
+    # The corresponding CDF is
+    #
+    # $P(x) = \frac{x-a}{b-a}$ for $a\leq x\leq b$ and zero elsewhere.
+    #
+    # The first and second moments of this distribution are:
+    #
+    # $\langle x \rangle = \frac{1}{2}(a+b)$ and $\sigma_x = \frac{b-a}{\sqrt{12}}$
+
+    from distgen.dist import Uniform
+
+    var = "x"
+    verbose = 1
+    params = {"min_x": 2 * unit_registry("mm"), "max_x": 4 * unit_registry("mm")}
+    uniform = Uniform(var, verbose=verbose, **params)
+    uniform.plot_pdf()
+    uniform.plot_cdf()
+    uniform.test_sampling()
+
+
+def test_normal_distribution():
+    # # Normal Distribution (including truncation)
+    #
+    # The general form of a normal distribution PDF with truncation is given by
+    #
+    # $\rho(x) =
+    # \frac{1}{\sigma}\frac{\phi\left(\frac{x-\mu}{\sigma}\right)}{\Phi\left(\frac{b-\mu}{\sigma}\right)-\Phi\left(\frac{a-\mu}{\sigma}\right)}$.
+    #
+    # In this expression $\phi(\xi) =
+    # \frac{1}{\sqrt{2\pi}}e^{-\frac{1}{2}\xi^2}$ is the canonical normal
+    # distribution, $\Phi(\xi) = \frac{1}{2}\left[1 +
+    # \text{erf}\left(\frac{\xi}{\sqrt{2}}\right) \right]$ is the canonical
+    # normal CDF, and $a=-N_{\text{cutoff}}\cdot\sigma$ and
+    # $b=-N_{\text{cutoff}}\cdot\sigma$ are the left and right truncation
+    # points.  The CDF if given by
+    #
+    # $P(x) = \frac{\Phi\left(\frac{x-\mu}{\sigma}\right) -
+    # \Phi\left(\frac{a-\mu}{\sigma}\right)}{\Phi\left(\frac{b-\mu}{\sigma}\right)-\Phi\left(\frac{a-\mu}{\sigma}\right)}$.
+    #
+    # Defining $\alpha = \frac{a-\mu}{\sigma}$ and $\beta =
+    # \frac{b-\mu}{\sigma}$, the first and second moments of the distribution
+    # are:
+    #
+    # $\langle x\rangle = \mu + \frac{\phi\left(\alpha\right) -
+    # \phi\left(\beta\right)}{\Phi\left(\beta\right)-\Phi\left(\alpha\right)}\sigma$
+    # and $\sigma_x = \sigma \left\{1 + \frac{\alpha\phi\left(\alpha\right) -
+    # \beta\phi(\beta) }{\Phi(\beta) - \Phi(\alpha)} -
+    # \left(\frac{\phi\left(\alpha\right) - \phi(\beta)}{\Phi(\beta) -
+    # \Phi(\alpha)}\right)^{2} \right\}^{1/2} $.
+    #
+    # When using this distribution, if the $N_{\text{cutoff}}$ is not set then
+    # the distribution reduces to an infinite range normal distribution, as
+    # first shown below:
+
+    from distgen.dist import Norm
+
+    var = "x"
+    verbose = 1
+    params = {"sigma_x": 2 * unit_registry("mm"), "avg_x": -1 * unit_registry("mm")}
+    norm = Norm(var, verbose=verbose, **params)
+    norm.plot_pdf()
+    norm.plot_cdf()
+    norm.test_sampling()
+
+
+def test_normal_distribution1():
+    # Below the $N_{\text{cutoff}}$ parameter is set to cut the distribution
+    # symmetrically:
+
+    from distgen.dist import Norm
+
+    var = "x"
+    verbose = 1
+    params = {
+        "sigma_x": 2 * unit_registry("mm"),
+        "avg_x": 0 * unit_registry("mm"),
+        "n_sigma_cutoff": 2,
+    }
+    norm = Norm(var, verbose=verbose, **params)
+    norm.plot_pdf()
+    norm.plot_cdf()
+    norm.test_sampling()
+
+
+def test_normal_distribution_2():
+    # The distribution can be truncated asymmetrically using the
+    # $N_{\text{cutoff},R}$ and $N_{\text{cutoff},L}$ parameters, as shown
+    # below.  Note in this case, it is only required that $N_{\text{cutoff},L}
+    # < N_{\text{cutoff},R}$, allowing for completley arbtitray location of the
+    # truncation points.  This requires a minus sign for the cut off parameters
+    # for truncation values less than zero.
+
+    from distgen.dist import Norm
+
+    params = {
+        "sigma_x": 2 * unit_registry("mm"),
+        "avg_x": 0 * unit_registry("mm"),
+        "n_sigma_cutoff_left": -1.5,
+        "n_sigma_cutoff_right": 1,
+    }
+
+    norm = Norm("x", verbose=1, **params)
+    norm.plot_pdf()
+    norm.plot_cdf()
+    norm.test_sampling()
+
+
+def test_super_gaussian():
+    # # Super Gaussian
+    #
+    # In additional to the regular Gaussian function, it is also possible to
+    # sample a super-Gaussian distribution defined by
+    #
+    # $\rho(x; \lambda, p) =
+    # \frac{1}{2\sqrt{2}\Gamma\left(1+\frac{1}{2p}\right)\lambda }
+    # \exp\left[-\left(\frac{(x-\mu)^2 }{2\lambda^2}\right)^{p}\right]$
+    #
+    # Here $\sigma_1$ is the length scale and $p$ is the power of the
+    # super-Gaussian. Note when $p=1$ reduces to a Normal distirbution, in
+    # which case $\sigma_x=\lambda$.  As $p\rightarrow\infty$ the distribution
+    # reduces to a flat-top (uniform). The full range of powers is given by
+    # $p\in\left(0,\infty\right]$.
+    #
+    # The first and second moments of the distribution are given by:
+    #
+    # $\langle x\rangle = \mu$, and $\sigma_x =
+    # \left(\frac{2\Gamma\left(1+\frac{3}{2p}\right)}{3\Gamma\left(1+\frac{1}{2p}\right)}\right)^{1/2}\lambda$.
+    #
+    #
+    # Often, it is convenient to scan the distribution from the uniform limit
+    # to the Gaussian limit.  To do some, the input $p$ can be parameterized by
+    # $\alpha\in[0,1]$ where $p = 1/\alpha$.  Here $\alpha=0$ corresponds to a
+    # flat-top (uniform) and $\alpha=1$ corresponds to a Gaussian.  Examples of
+    # both types of usage are shown below.
+
+    from distgen.dist import SuperGaussian
+
+    ps = [0.5, 1, 5, float("Inf")]
+    alphas = [0, 0.25, 0.5, 1]
+
+    fig, (ax1, ax2) = plt.subplots(
+        1, 2, sharex="col", figsize=(12, 4), constrained_layout=True
+    )
+
+    plegs = ["p = " + str(p) for p in ps]
+    alegs = ["$\\alpha$ = " + str(a) for a in alphas]
+
+    for ii, p in enumerate(ps):
+        pparams = {
+            "lambda": 2 * unit_registry("mm"),
+            "p": p * unit_registry("dimensionless"),
+        }
+
+        supG = SuperGaussian("x", verbose=0, **pparams)
+        x = supG.get_x_pts(1000)
+        rho = supG.pdf(x)
+        ax1.plot(x, rho)
+        a = alphas[ii]
+        aparams = {
+            "lambda": 2 * unit_registry("mm"),
+            "alpha": a * unit_registry("dimensionless"),
+        }
+
+        x = np.linspace(-3 * aparams["lambda"], 3 * aparams["lambda"], 100)
+        supG = SuperGaussian("x", verbose=0, **aparams)
+        rho = supG.pdf(x)
+        ax2.plot(x, rho)
+
+    ax1.set_xlabel("x (mm)")
+    ax2.set_xlabel("x (mm)")
+    ax1.set_ylabel("pdf (1/mm)")
+    ax2.set_ylabel("pdf (1/mm)")
+    ax1.legend(plegs)
+    ax2.legend(alegs)
+    # To set the length scale of the distribution, the user must either supply 'sigma_[var]' or 'lambda'. See usage below:
+
+    params = {
+        "sigma_x": 2 * unit_registry("mm"),
+        #'alpha': 0.75*unit_registry('dimensionless'),
+        "alpha": 0.003 * unit_registry("dimensionless"),
+        "avg_x": 0.25 * unit_registry("mm"),
+    }
+
+    supG = SuperGaussian("x", verbose=1, **params)
+    supG.plot_pdf()
+    supG.plot_cdf()
+    supG.test_sampling()
+
+
+def test_1d_pdf_from_file():
+    # # 1D PDF from a file
+
+    # Distgen supports importing a 1D PDF saved in column form in.  The input
+    # form of the file should have space separated headers such as $x$ and
+    # $Px$, with corresponding column data below it.  The PDF is normalized
+    # numerically using the numpy.trapz numerical integration routine. The CDF
+    # is computed using the scipy.cumtrapz cumulative numerical intgration
+    # routine.
+    #
+    # The following example shows a gaussian PDF with cuts added to it.
+
+    from distgen.dist import File1d
+
+    var = "t"
+    verbose = 1
+    params = {"file": str(EXAMPLES_DATA_PATH / "cutgauss.1d.txt"), "units": "ps"}
+    file1d = File1d(var, verbose=verbose, **params)
+    file1d.plot_pdf()
+    file1d.plot_cdf()
+    file1d.test_sampling()
+
+
+def test_pulsed_laser_soliton():
+    # # $sech^2$ - Pulsed Laser Soliton
+
+    from distgen.dist import Sech2
+
+    verbose = 1
+    # params={'tau':1.0*unit_registry('ps'), 'avg_t':1.0*unit_registry('ps')}
+    params = {"sigma_t": 1.0 * unit_registry("ps"), "avg_t": 1.0 * unit_registry("ps")}
+    laser_pulse = Sech2(verbose=verbose, **params)
+
+    laser_pulse.plot_pdf()
+    laser_pulse.plot_cdf()
+    laser_pulse.test_sampling()
+
+
+def test_laser_pulse_stacking():
+    # # Laser pulse stacking
+
+    from distgen.dist import TemporalLaserPulseStacking
+
+    verbose = 1
+    params = {
+        "crystal_length_1": 15.096 * unit_registry("mm"),
+        "crystal_length_2": 7.548 * unit_registry("mm"),
+        "crystal_length_3": 3.774 * unit_registry("mm"),
+        "crystal_length_4": 1.887 * unit_registry("mm"),
+        "crystal_angle_1": 0.6 * unit_registry("deg"),
+        "crystal_angle_2": 1.8 * unit_registry("deg"),
+        "crystal_angle_3": -0.9 * unit_registry("deg"),
+        "crystal_angle_4": -0.5 * unit_registry("deg"),
+    }
+
+    laser_pulse = TemporalLaserPulseStacking(verbose=verbose, **params)
+    laser_pulse.plot_pdf()
+    laser_pulse.plot_cdf()
+    laser_pulse.test_sampling()
+
+
+def test_tukey_1d():
+    # # Tukey 1D
+
+    from distgen.dist import Tukey
+
+    var = "y"
+    verbose = 1
+    params = {
+        "length": 2 * unit_registry("mm"),
+        "ratio": 0.75 * unit_registry("dimensionless"),
+    }
+    tukey = Tukey(var, verbose=1, **params)
+    tukey.plot_pdf()
+    tukey.plot_cdf()
+    tukey.test_sampling()
+
+
+def test_superposition_1d():
+    # # Superposition 1D
+
+    from distgen.dist import Superposition
+
+    params = {
+        "dists": {
+            "d1": {
+                "avg_z": -1 * unit_registry("mm"),
+                "sigma_z": 1 * unit_registry("mm"),
+                "type": "gaussian",
+            },
+            "d2": {
+                "avg_z": +1 * unit_registry("mm"),
+                "sigma_z": 1 * unit_registry("mm"),
+                "type": "gaussian",
+            },
+        }
+    }
+
+    sup = Superposition("z", 1, **params)
+    sup.plot_pdf()
+    sup.plot_cdf()
+    sup.test_sampling()
+
+
+def test_maxwell_boltzmann_distribution():
+    # # Maxwell-Boltzmann Distribution
+
+    from distgen.dist import MaxwellBoltzmannDist
+
+    params = {"scale_p": 10 * unit_registry("eV/c")}
+
+    mb = MaxwellBoltzmannDist("p", verbose=0, **params)
+
+    mb.plot_pdf()
+    mb.plot_cdf()
+    mb.test_sampling()
+
+
+def test_radial_distributions():
+    # # Radial Distributions
+    # ---
+
+    from distgen.dist import UniformRad
+
+    verbose = 1
+    params = {"min_r": 1 * unit_registry("mm"), "max_r": 2 * unit_registry("mm")}
+    urad = UniformRad(verbose=1, **params)
+    urad.plot_pdf()
+    urad.plot_cdf()
+    urad.test_sampling()
+
+
+def test_radial_normal_distribution_truncation():
+    # # Radial Normal Distribution (with truncation)
+    #
+    # The radial normal distribution including truncation(s) has a probability
+    # function given by
+    #
+    # $\rho_r(r) =
+    # \frac{1}{\sigma^2}\frac{\phi(r/\sigma)}{\phi\left(\frac{r_L}{\sigma}\right)-\phi\left(\frac{r_R}{\sigma}\right)}
+    # $ for $0 \leq r_L \leq r \leq r_R$ and zero everywhere else.
+    #
+    # In this expresion $\phi(\xi) = \frac{1}{2\pi}\exp\left(-\xi^2/2\right)$
+    # is the canonical raidial normal distirbution (no truncation), and the
+    # scale parameter $\sigma$ follows from the product of two normal
+    # distributions in $x$ and $y$ when $\sigma=\sigma_x=\sigma_y$.  The
+    # corresponding CDF is given by
+    #
+    # $P(r)=
+    # \frac{\phi\left(\frac{r_L}{\sigma}\right)-\phi\left(\frac{r}{\sigma}\right)}{\phi\left(\frac{r_L}{\sigma}\right)-\phi\left(\frac{r_R}{\sigma}\right)}
+    # $ for $0 \leq r_L \leq r$.
+    #
+    # The corresponding first and second moments are:
+    #
+    # $\langle r\rangle =
+    # \frac{\frac{r_L}{\sigma}\phi\left(\frac{r_L}{\sigma}\right)
+    # -\frac{r_R}{\sigma}\phi\left(\frac{r_R}{\sigma}\right)
+    # +\frac{1}{2\sqrt{2\pi}}\left(
+    # \text{erf}\left(\frac{r_R}{\sigma\sqrt{2}}\right) -
+    # \text{erf}\left(\frac{r_L}{\sigma\sqrt{2}}\right) \right) }
+    # {\phi\left(\frac{r_L}{\sigma}\right)-\phi\left(\frac{r_R}{\sigma}\right)}$,
+    #
+    # $r_{rms} = \sqrt{ 2\sigma^2 + r_L^2 -
+    # \frac{(r_R^2-r_L^2)\phi(r_R/\sigma)}{\phi\left(\frac{r_L}{\sigma}\right)-\phi\left(\frac{r_R}{\sigma}\right)}
+    # }$.
+    #
+    # Note that in the limits $r_L\rightarrow 0$ and $r_R -> \infty$ the above
+    # expressions reduce to the underlying radial normal distribution:
+    #
+    # $\rho_r(r)\rightarrow
+    # \frac{\phi\left(\frac{r}{\sigma}\right)}{\sigma^2}$, $P(r)\rightarrow 1 -
+    # \phi\left(\frac{r}{\sigma}\right)$, $\langle r\rangle\rightarrow
+    # \sqrt{\frac{\pi}{2}}\sigma$, and $r_{rms}\rightarrow \sqrt{2}\sigma$.
+    # This limiting case is shown first below.
+    #
+
+    from distgen.dist import NormRad
+
+    verbose = 1
+    params = {"sigma_xy": 1 * unit_registry("mm")}
+    nrad = NormRad(verbose=1, **params)
+    nrad.plot_pdf()
+    nrad.plot_cdf()
+    nrad.test_sampling()
+
+
+def test_radial_normal_distribution_truncation1():
+    # For laser scientists it can be convenient to to work with a pinhole radius and a fraction of the laser intensity to clip a transverse normal laser mode at.  In this case the user can supply a truncation radius ($=r_R$) and a truncation fraction $f = \exp\left(-\frac{r_R^2}{2\sigma}\right)$ from which distgen determines the underlying $\sigma$.  The example below demonstrates this usage:
+
+    from distgen.dist import NormRad
+
+    verbose = 1
+    params = {
+        "truncation_radius": 1 * unit_registry("mm"),
+        "truncation_fraction": 0.5 * unit_registry("dimensionless"),
+    }
+    nrad = NormRad(verbose=1, **params)
+    nrad.plot_pdf()
+    nrad.plot_cdf()
+    nrad.test_sampling()
+
+
+def test_radial_normal_distribution_truncation2():
+    from distgen.dist import NormRad
+
+    params = {"sigma_xy": 2 * unit_registry("mm"), "n_sigma_cutoff": 1}
+    nrad = NormRad(verbose=1, **params)
+    nrad.plot_pdf()
+    nrad.plot_cdf()
+    nrad.test_sampling()
+
+
+def test_radial_tukey():
+    # # Radial Tukey
+
+    from distgen.dist import TukeyRad
+
+    params = {
+        "length": 1 * unit_registry("mm"),
+        "ratio": 0.75 * unit_registry("dimensionless"),
+    }
+    rtukey = TukeyRad(verbose=1, **params)
+    rtukey.plot_pdf()
+    rtukey.plot_cdf()
+    rtukey.test_sampling()
+
+
+def test_radial_super_gaussian():
+    # # Radial Super Gaussian This implements a radial version of the Super
+    # Gaussian function discussed above.  Here the radial function takes the
+    # form:
+    #
+    # $2\pi\rho(r;\lambda,p) =
+    # \frac{1}{\Gamma\left(1+\frac{1}{p}\right)\lambda^2}
+    # \exp\left[-\left(\frac{r^2}{2\lambda^2}\right)^p\right]$. The
+    # corrsponding CDF is: ?
+    #
+    # The first and (rms) second moment of the distribution are given by:
+    #
+    # $\langle r\rangle =
+    # \frac{2\sqrt{2}}{3}\frac{\Gamma\left(1+\frac{3}{2p}\right)}{\Gamma\left(1+\frac{1}{p}\right)}\lambda$,
+    #
+    # $r_{\text{rms}} =
+    # \sqrt{\frac{\Gamma\left(1+\frac{2}{p}\right)}{\Gamma\left(1+\frac{1}{p}\right)}}\lambda$.
+    #
+
+    from distgen.dist import SuperGaussianRad
+
+    params = {
+        "sigma_xy": 1 * unit_registry("mm"),
+        "alpha": 0.50 * unit_registry("dimensionless"),
+    }
+    supG = SuperGaussianRad(verbose=1, **params)
+    supG.plot_pdf()
+    supG.plot_cdf()
+    supG.test_sampling()
+
+
+def test_radial_file_distribution():
+    # Radial File Distribution
+
+    from distgen.dist import RadFile
+
+    params = {"file": str(EXAMPLES_DATA_PATH / "cutgauss.rad.txt"), "units": "mm"}
+
+    rfd = RadFile(verbose=1, **params)
+    rfd.plot_pdf()
+    rfd.plot_cdf()
+    rfd.test_sampling()
+
+
+# Angular Distributions (TODO)
+# ---
+# Angular distributions define one dimensional probability functions for the cylindrical variable $\theta$.

--- a/distgen/tests/test_import.py
+++ b/distgen/tests/test_import.py
@@ -1,0 +1,4 @@
+def test_importable():
+    import distgen
+
+    print("Distgen version is:", distgen.__version__)

--- a/distgen/writers.py
+++ b/distgen/writers.py
@@ -210,7 +210,7 @@ def fstr(s):
     """
     Makes a fixed string for h5 files
     """
-    return np.string_(s)
+    return np.bytes_(s)
 
 
 
@@ -293,7 +293,7 @@ def opmd_init(h5):
         'particlesPath':'particles/'        
     }
     for k,v in d.items():
-        h5.attrs[k] = np.string_(v)
+        h5.attrs[k] = np.bytes_(v)
     h5.create_group('/data/')
 
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - openpmd-beamphysics
   - lume-base
   - pydicom
-# Developer
+  # Developer
   - pytest
   - poppler
   - jupyterlab>=3
@@ -25,5 +25,6 @@ dependencies:
   - mkdocs-jupyter
   - pip
   - pip:
-    - mkdocstrings-python
-
+      - mkdocstrings-python
+      # Install distgen as well
+      - .

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -15,6 +15,7 @@ dependencies:
   - pydicom
   # Developer
   - pytest
+  - pytest-cov
   - poppler
   - jupyterlab>=3
   - ipywidgets

--- a/environment.yml
+++ b/environment.yml
@@ -13,3 +13,7 @@ dependencies:
   - openpmd-beamphysics
   - lume-base
   - pydicom
+  - pip
+  - pip:
+      # Install distgen as well
+      - .


### PR DESCRIPTION
* numpy 2.0 was recently released and has broken a few codebases, including distgen
   * `np.string_` -> `np.bytes_`
   * `np.Inf` -> `np.inf`
   * Full migration guide is here: https://numpy.org/devdocs/numpy_2_0_migration_guide.html#numpy-2-migration-guide
* Added some tests based on the regression test notebooks. I only converted two:
   * `beam`: This was easy to parametrize with pytest fixtures based on how nicely you had the notebook laid out.
   * `dist`:  This was relatively easy to convert as most of the tests were standalone
* Added GitHub Actions test runners for the supported Python versions