### PR TITLE
FIX: a few more numpy2 removals

### DIFF
--- a/distgen/dist.py
+++ b/distgen/dist.py
@@ -220,7 +220,7 @@ class Dist1d(Dist):
         self.Px = Px
         self.xstr = xstr
         
-        norm = np.trapz(self.Px, self.xs)
+        norm = np.trapezoid(self.Px, self.xs)
         if(norm<=0):
             raise ValueError('Normalization of PDF was <= 0')
 
@@ -313,7 +313,7 @@ class Dist1d(Dist):
 
         rho, edges = histogram(xs, nbins=100)
         xc = centers(edges)
-        rho = rho/np.trapz(rho, xc)
+        rho = rho/np.trapezoid(rho, xc)
 
         savgx = xs.mean()
         sstdx = xs.std()
@@ -1406,12 +1406,12 @@ class Deformable(Dist1d):
         Px = Px*self.dist['linear'].pdf(xs)
 
 
-        norm = np.trapz(Px, xs)
+        norm = np.trapezoid(Px, xs)
         assert norm > 0, 'Error: derformable distribution can not be normalized.'
         Px = Px/norm
 
-        avgx = np.trapz(xs*Px, xs)
-        stdx = np.sqrt(np.trapz( Px*(xs-avgx)**2, xs))
+        avgx = np.trapezoid(xs*Px, xs)
+        stdx = np.sqrt(np.trapezoid( Px*(xs-avgx)**2, xs))
 
         #print(avgx, stdx)
 

--- a/distgen/metrics.py
+++ b/distgen/metrics.py
@@ -24,8 +24,8 @@ from .dist import SuperGaussian
 #--------------------------------------------------------------
 
 def mean_and_sigma(x, rho):
-    x0 = np.trapz(rho*x, x)
-    x2 = np.trapz(rho*(x-x0)**2, x)
+    x0 = np.trapezoid(rho*x, x)
+    x2 = np.trapezoid(rho*(x-x0)**2, x)
     
     return x0, np.sqrt(x2)
 
@@ -85,7 +85,7 @@ def kullback_liebler_div(xp, P, xq, Q, adjusted=False, as_float=True):
     Q0 = Q[p_and_q_nonzero]
     x0 = xi[p_and_q_nonzero]
     
-    KLdiv = np.trapz(P0*( np.log(P0/Q0) ), x0 )
+    KLdiv = np.trapezoid(P0*( np.log(P0/Q0) ), x0 )
     
     if(as_float):
         return KLdiv.magnitude
@@ -98,11 +98,11 @@ def res2(xp, P, xq, Q, as_float=True, normalize=False):
     xi, P, Q = resample_pq(xp, P, xq, Q)  # Interpolates to same grid, and renormalizes
     
     if(normalize):
-        N = np.trapz(Q**2, xi)
+        N = np.trapezoid(Q**2, xi)
     else:
         N=1
     
-    residuals2 = np.trapz((P-Q)**2, xi) / N
+    residuals2 = np.trapezoid((P-Q)**2, xi) / N
     
     if(as_float):
         return residuals2.magnitude
@@ -141,7 +141,7 @@ def get_1d_profile(particle_group, var, bins=None):
 def get_current_profile(particle_group, bins=None):
 
     t, rho = get_1d_profile(particle_group, 't', bins=bins)
-    return t, particle_group.charge*rho/np.trapz(rho, t)
+    return t, particle_group.charge*rho/np.trapezoid(rho, t)
 
 
 #--------------------------------------------------------------------

--- a/distgen/plot.py
+++ b/distgen/plot.py
@@ -200,7 +200,7 @@ def map_hist(x, y, h, bins):
     vals = h.flatten()[inds]
     bads = ((x < bins[0][0]) | (x > bins[0][-1]) |
             (y < bins[1][0]) | (y > bins[1][-1]))
-    vals[bads] = np.NaN
+    vals[bads] = np.nan
     return vals
 
 

--- a/distgen/tools.py
+++ b/distgen/tools.py
@@ -131,7 +131,7 @@ def trapz(f, x):
     """ 
     Numerically integrates f(x) using trapezoid method.
     """
-    return np.trapz(f, x)
+    return np.trapezoid(f, x)
 
 
 @unit_registry.wraps('=A*B', ('=B', '=A'))


### PR DESCRIPTION
Sorry, @ColwynGulliford, a couple more fixes that I missed. A follow-up to #19 

* `np.NaN` -> `np.nan`
* `np.trapz` -> [`np.trapezoid`](https://numpy.org/devdocs/reference/generated/numpy.trapezoid.html)