### PR TITLE
ENH: make pydicom optional

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
+          miniforge-version: latest
           channels: conda-forge
           activate-environment: distgen
           environment-file: environment-dev.yml

--- a/distgen/tests/test_beam.py
+++ b/distgen/tests/test_beam.py
@@ -43,6 +43,12 @@ def yaml_file(request: pytest.FixtureRequest) -> pathlib.Path:
 
 @pytest.fixture(scope="module")
 def beam(yaml_file: pathlib.Path) -> Beam:
+    if yaml_file.name == "dcm.image.in.yaml":
+        from ..tools import dicom
+
+        if dicom is None:
+            pytest.skip("pydicom unavailable")
+
     G = Generator(str(yaml_file), verbose=0)
     G["n_particle"] = 10_000
     return G.beam()

--- a/distgen/tools.py
+++ b/distgen/tools.py
@@ -11,8 +11,10 @@ import matplotlib.image as mpimg
 import datetime
 import os
 
-import pydicom as dicom
-
+try:
+    import pydicom as dicom
+except ImportError:
+    dicom = None
 
 from pathlib import Path
 
@@ -433,10 +435,16 @@ def get_file_extension(filename):
     
 
 
-SUPPORTED_IMAGE_EXTENSIONS = ['.dicom', '.dcm',
-                              '.jpeg', '.jpg', 
-                              '.png', 
-                              '.tiff',]
+SUPPORTED_IMAGE_EXTENSIONS = [
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".tiff",
+]
+
+if dicom is not None:
+    SUPPORTED_IMAGE_EXTENSIONS.extend(['.dicom', '.dcm'])
+
 
 def read_image_file(filename, rgb_weights = [0.2989, 0.5870, 0.1140]):
 
@@ -445,7 +453,13 @@ def read_image_file(filename, rgb_weights = [0.2989, 0.5870, 0.1140]):
     if file_extension not in SUPPORTED_IMAGE_EXTENSIONS:
         raise ValueError(f'Image file extension "{file_extension}" is not supported.')
     
-    elif file_extension == '.dcm':
+    elif file_extension in {'.dcm', '.dicom'}:
+        if dicom is None:
+            raise RuntimeError(
+                "To read dicom image files, please install pydicom. "
+                "Please note that as of September 2024, it is only "
+                "compatible with Python 3.10+."
+            )
         img = dicom.dcmread(filename).pixel_array
         
     else:

--- a/distgen/tools.py
+++ b/distgen/tools.py
@@ -14,6 +14,10 @@ import os
 try:
     import pydicom as dicom
 except ImportError:
+    # The optional pydicom library is not installed.
+    dicom = None
+except TypeError:
+    # pydicom is unavailable on Python 3.9 as it uses python 3.10+ features.
     dicom = None
 
 from pathlib import Path


### PR DESCRIPTION
## Changes

Make pydicom optional, as it only supports Python 3.10+ currently.
This will allow Python 3.9 users to continue to use distgen, just without DCM-reading capabilities.