### PR TITLE
Pinning python to 3.12 due to PINT issue #1969

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ name: distgen-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9
+  - python>=3.9,<3.13
   - matplotlib-base
   - numpy
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: distgen
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9
+  - python>=3.9,<3.13
   - matplotlib-base
   - numpy
   - scipy
@@ -13,7 +13,3 @@ dependencies:
   - openpmd-beamphysics
   - lume-base
   - pydicom
-  - pip
-  - pip:
-      # Install distgen as well
-      - .


### PR DESCRIPTION
Awaiting a bug fix in PINT for use with Python 3.13, pin Distgen to 3.12 for now.