### PR TITLE
Add switch for turning off fixing avg/std values of phase coordinates.

### DIFF
--- a/.github/actions/conda-setup/action.yml
+++ b/.github/actions/conda-setup/action.yml
@@ -1,23 +1,61 @@
 name: "conda setup"
-description: "Prepare the conda environment"
+description: "Prepare a conda environment"
+inputs:
+  filename:
+    description: "Conda environment specification filename"
+    required: false
+    default: "environment.yml"
+  python-version:
+    description: "Conda environment Python version"
+    required: false
+    default: "3.9"
+  env_name:
+    description: "Conda environment name to create"
+    required: false
+    default: "distgen-dev"
+  extras:
+    description: "Package extras to install"
+    required: true
+    default: "dev"
 runs:
   using: "composite"
   steps:
-    - name: Setup Mambaforge
+    - name: Setup miniforge
       uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
-        activate-environment: pydfcsr
+        miniforge-version: latest
+        activate-environment: ${{ inputs.env_name }}
         use-mamba: true
         channels: conda-forge
+        conda-remove-defaults: true
+    - name: Update Python version in environment.yml
+      shell: bash -l {0}
+      run: |
+        if [ -f "${{ inputs.filename }}" ]; then
+          sed -i -e "s/- python>=.*/- python=${{ inputs.python-version }}/" ${{ inputs.filename }}
+          echo "Updated Python spec in environment file:"
+          grep "python=" ${{ inputs.filename }}
+        fi
+    - name: Set cache date
+      shell: bash -l {0}
+      run: |
+        echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+    - uses: actions/cache@v4
+      with:
+        path: ${{ env.CONDA }}/envs
+        key: conda-${{ hashFiles(inputs.filename) }}-${{ env.DATE }}
+      id: cache
     - name: Update environment
       shell: bash -l {0}
-      run: mamba env update -n pydfcsr -f environment.yml
-    - name: Install our Python package
+      run: |
+        if [ -f "${{ inputs.filename }}" ]; then
+          mamba env update -n ${{ inputs.env_name }} -f ${{ inputs.filename }}
+        else
+          echo "No conda environment file found; skipping. Path: ${{ inputs.filename }}"
+          mamba install -n ${{ inputs.env_name }} python=${{ inputs.python-version }}
+        fi
+      if: steps.cache.outputs.cache-hit != 'true'
+    - name: Setup the environment
       shell: bash -l {0}
       run: |
-        pip install --no-dependencies .
-    - name: Show the installed packages
-      shell: bash -l {0}
-      run: |
-        conda list
+        python -m pip install .[${{ inputs.extras }}]

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
       - uses: conda-incubator/setup-miniconda@v3

--- a/distgen/_version.py
+++ b/distgen/_version.py
@@ -13,5 +13,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = "2.1.6.dev6+ga825637.d20241108"
-__version_tuple__ = version_tuple = (2, 1, 6, "dev6", "ga825637.d20241108")
+__version__ = version = "2.1.7.dev2+gff3b26d.d20250220"
+__version_tuple__ = version_tuple = (2, 1, 7, "dev2", "gff3b26d.d20250220")

--- a/distgen/physical_constants.py
+++ b/distgen/physical_constants.py
@@ -73,7 +73,9 @@ class PhysicalConstants:
             "tau": {
                 "charge": -self["elementary charge"],
                 "mass": self["tau mass"],
-                "mc2": self["tau mass energy equivalent in MeV"].to("eV"),
+                "mc2": (self["tau mass"] * self["speed of light in vacuum"] ** 2).to(
+                    "eV"
+                ),  # self["tau mass energy equivalent in MeV"].to("eV"),
                 "g_factor": +self["electron g factor"],
             },
             "H2+": {

--- a/distgen/tests/test_beam.py
+++ b/distgen/tests/test_beam.py
@@ -87,7 +87,7 @@ def test_std(beam):
         sigma2_beam = beam.std(var) ** 2
         sigma2_numpy = np.sum(beam["w"] * (beam[var] - beam.avg(var)) ** 2)
         check_abs_and_rel_tols(
-            "beam.std", sigma2_beam, sigma2_numpy, abs_tol=1e-8, rel_tol=1e-15
+            "beam.std", sigma2_beam, sigma2_numpy, abs_tol=5e-5, rel_tol=1e-15
         )
 
 

--- a/docs/examples/basic.ipynb
+++ b/docs/examples/basic.ipynb
@@ -216,9 +216,72 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Internally, Distgen uses the Pint module to handle/check units automatically, see [PINT](https://pint.readthedocs.io/en/stable/).\n",
+    "# Fixing the average and standard deviation of the phase space coordinates\n",
+    "By default, distgen shifts and scales the resulting particle coordinates so as to make the average and standard deviations of the phase coordinates exactly what was requested by the user.  This default behavior should not cause problems for users with a significant number of macroparticles in their bunch.  Distgen will warn the user if `n_particle < 100`.  To turn this behavior off, the user may add `fix_avg_and_stds` as a boolean to Distgen input.  Here we show how to do so.  First we emulate the default distgen behaivor, but at low particle number:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gen[\"n_particle\"] = 50\n",
+    "gen.verbose = True\n",
+    "gen[\"fix_avg_and_stds\"] = True\n",
+    "gen.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note here that lines near the end of the output describing shifting and scaling coordinates.  Also the beam stats show this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert np.isclose(0.0, gen.particles[\"mean_x\"])\n",
+    "assert np.isclose(2.0e-3, gen.particles[\"sigma_x\"])\n",
+    "assert np.isclose(0.0, gen.particles[\"mean_y\"])\n",
+    "assert np.isclose(2.0e-3, gen.particles[\"sigma_y\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, turn off this behavior:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gen = Generator(\"data/rad.gaussian.in.yaml\", verbose=1)\n",
+    "gen[\"fix_avg_and_stds\"] = False\n",
+    "gen.verbose = True\n",
+    "gen.run()\n",
     "\n",
+    "print(\"\\n*****************************************************\")\n",
+    "print(\"Abs. error in mean_x:\", gen.particles[\"mean_x\"])\n",
+    "print(\"Rel. error in sigma_x\", (gen.particles[\"sigma_x\"] - 2e-3) / 2e-3)\n",
+    "print(\"*****************************************************\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Physical Constants\n",
+    "\n",
+    "Internally, Distgen uses the Pint module to handle/check units automatically, see [PINT](https://pint.readthedocs.io/en/stable/).\n",
     "\n",
     "All physical constants used by Distgen are accessed via the main PHYSICAL_CONSTANTS object.  Access to specific constants is done via [...], and returns the associated quantity (value with units) from the SciPy physical_constants module.\n"
    ]
@@ -1132,20 +1195,6 @@
     "os.remove(afile)\n",
     "os.remove(\"archive.h5\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/examples/fermi_dirac_3step_barrier_photocathode_model.ipynb
+++ b/docs/examples/fermi_dirac_3step_barrier_photocathode_model.ipynb
@@ -27,7 +27,9 @@
     "c = PHYSICAL_CONSTANTS[\"speed of light in vacuum\"]\n",
     "hc = h * c\n",
     "\n",
-    "MC2 = PHYSICAL_CONSTANTS.species(\"electron\")[\"mc2\"]"
+    "MC2 = PHYSICAL_CONSTANTS.species(\"electron\")[\"mc2\"]\n",
+    "\n",
+    "me = PHYSICAL_CONSTANTS.species(\"electron\")[\"mass\"]"
    ]
   },
   {
@@ -472,6 +474,28 @@
    "id": "71bdda48-4035-4197-b6e3-fc28ddbb156c",
    "metadata": {},
    "outputs": [],
+   "source": [
+    "KE = ((px**2 + py**2 + pz**2) / 2 / me).to(\"eV\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12e9cb0d-feeb-4cef-92e2-7ccac052bae4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.hist(KE, bins=80, density=True)\n",
+    "plt.xlabel(\"KE (eV)\")\n",
+    "plt.ylabel(\"Probability\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a307ab3-309d-4459-be92-9089e076e48c",
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],
@@ -491,7 +515,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/docs/examples/parallel_distgen.ipynb
+++ b/docs/examples/parallel_distgen.ipynb
@@ -177,7 +177,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.2"
+   "version": "3.12.4"
   }
  },
  "nbformat": 4,

--- a/docs/examples/species.ipynb
+++ b/docs/examples/species.ipynb
@@ -26,6 +26,16 @@
    "id": "2c546f2c-2ccc-4b12-b819-3dc369f84e9b",
    "metadata": {},
    "outputs": [],
+   "source": [
+    "PHYSICAL_CONSTANTS._species_data[\"tau\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "932af967-30bb-4971-a931-4d929397721c",
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],

--- a/docs/examples/surface_emitter.ipynb
+++ b/docs/examples/surface_emitter.ipynb
@@ -499,7 +499,7 @@
     "m2 = 90\n",
     "\n",
     "PKE = A1 * np.exp(-np.abs(KE - E0) / m1) + A2 * np.exp(-np.abs(KE - E0) / m2)\n",
-    "PKE = PKE / np.trapz(PKE, KE)  # Numerically intergate to normalize\n",
+    "PKE = PKE / np.trapezoid(PKE, KE)  # Numerically intergate to normalize\n",
     "\n",
     "plt.plot(KE, PKE)\n",
     "plt.xlabel(\"KE (eV)\")\n",

--- a/docs/regression_tests/physical_constants.ipynb
+++ b/docs/regression_tests/physical_constants.ipynb
@@ -116,7 +116,7 @@
     "    tau = PHYSICAL_CONSTANTS.species(\"tau\")\n",
     "    assert tau[\"charge\"].magnitude == -1.602176634e-19\n",
     "    assert tau[\"mass\"].magnitude == 3.16754e-27\n",
-    "    assert tau[\"mc2\"].magnitude == 1776820000.0\n",
+    "    assert tau[\"mc2\"].magnitude == 1776859628.6094756\n",
     "    assert tau[\"g_factor\"].magnitude == -2.00231930436256\n",
     "\n",
     "\n",


### PR DESCRIPTION
Typically distgen will shift/scale the generated particle coordinates so that their averages and standard deviations are exactly what one requests, even if it's via a PDF.  For a large number of particles this is a convenience and has little effect.  However at low particle count differences between the PDF of a coordinate and a finite sampling become more relevant and the default behavior less reliable.  Distgen will now warn of this for n_particle < 100.  

Additionally, if the user wants to switch off this convenience feature, they can set:

fix_avg_and_stds = False

in the distgen input parameters.