### PR TITLE
Fix gh-pages workflow: update to v3/v4 actions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,17 +8,13 @@ on:
 jobs:
   deploy:
     if: ${{ github.repository == 'ColwynGulliford/distgen' }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: ["3.10"]
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
+          python-version: "3.12"
+          miniforge-version: latest
           channels: conda-forge
           activate-environment: distgen-dev
           environment-file: environment-dev.yml
@@ -37,7 +33,7 @@ jobs:
           mv distgen-examples.zip ./site/assets/.
 
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site/


### PR DESCRIPTION
- actions/checkout@v3 -> @v4 (Node.js 24)
- conda-incubator/setup-miniconda@v2 -> @v3 with miniforge
- peaceiris/actions-gh-pages@v3 -> @v4 (Node.js 24)
- Remove deprecated mamba-version setting
- Update Python 3.10 -> 3.12
- Remove unnecessary matrix strategy