### PR TITLE
Re-enable input archiving and fix particle group nesting in `Generator` archives

### DIFF
--- a/distgen/archive.py
+++ b/distgen/archive.py
@@ -65,6 +65,9 @@ def write_input_h5(h5, distgen_input, name="input"):
     g = h5.create_group(name)
     d = flatten_dict(distgen_input)
     for k, v in d.items():
+        if v is None:
+            # h5py cannot store None (object dtype); absent == None on read
+            continue
         g.attrs[k] = v
 
 

--- a/distgen/generator.py
+++ b/distgen/generator.py
@@ -1,4 +1,3 @@
-from pprint import pprint
 import warnings
 
 import numpy as np
@@ -109,7 +108,9 @@ class Generator(Base):
                 # Try raw string
                 input = yaml.safe_load(input)
                 if not isinstance(input, dict):
-                    raise ValueError(f"ERROR: parsing unsuccessful, could not read {input}")
+                    raise ValueError(
+                        f"ERROR: parsing unsuccessful, could not read {input}"
+                    )
                 expand_input_filepaths(input)
 
         else:
@@ -210,8 +211,8 @@ class Generator(Base):
             "output",
             "transforms",
             "start",
-            #"random_seed",
-            #"random_type",
+            # "random_seed",
+            # "random_type",
             "random",
             "spin_polarization",
             "spin_orientation",
@@ -220,9 +221,7 @@ class Generator(Base):
 
         for p in params:
             if p not in allowed_params and not p.endswith("_dist"):
-                raise ValueError(
-                    "Unexpected distgen input parameter: " + p
-                )
+                raise ValueError("Unexpected distgen input parameter: " + p)
 
         if params["n_particle"] <= 0:
             raise ValueError("User must specify n_particle > 0.")
@@ -239,36 +238,49 @@ class Generator(Base):
             )
 
         if "nd_gaussian_dist" in params:
-
             # Get the variables specified in the distribution via the required centroid:
             allowed_nd_gaussian_dist_vars = ["x", "y", "z", "px", "py", "pz"]
 
             if "centroid" not in params["nd_gaussian_dist"]:
-                raise ValueError("nd_gaussian_dist must include a 'centroid' field specifying the variables included in the distribution.")
+                raise ValueError(
+                    "nd_gaussian_dist must include a 'centroid' field specifying the variables included in the distribution."
+                )
 
-            nd_gaussian_dist_vars = [p for p in params['nd_gaussian_dist']['centroid'].keys()]
-            #print(nd_gaussian_dist_vars)
+            nd_gaussian_dist_vars = [
+                p for p in params["nd_gaussian_dist"]["centroid"].keys()
+            ]
+            # print(nd_gaussian_dist_vars)
 
             for var in nd_gaussian_dist_vars:
                 if var not in allowed_nd_gaussian_dist_vars:
-                    raise ValueError(f"Invalid variable specified in nd_gaussian_dist: {var}")
-                
+                    raise ValueError(
+                        f"Invalid variable specified in nd_gaussian_dist: {var}"
+                    )
+
             if len(nd_gaussian_dist_vars) == 0:
                 raise ValueError("No valid variables specified in nd_gaussian_dist.")
-            
+
             if len(nd_gaussian_dist_vars) > 6:
                 raise ValueError("Too many variables specified in nd_gaussian_dist.")
 
-            other_dist_vars = [p.replace("_dist", "") for p in params if p.endswith("_dist") and p != 'nd_gaussian_dist']
+            other_dist_vars = [
+                p.replace("_dist", "")
+                for p in params
+                if p.endswith("_dist") and p != "nd_gaussian_dist"
+            ]
 
             for other_var in other_dist_vars:
                 if other_var in nd_gaussian_dist_vars:
-                    raise ValueError(f"Variable {other_var} specified in both nd_gaussian_dist and as separate distribution.")
-                
-            if params['start']['type'] == 'cathode':
+                    raise ValueError(
+                        f"Variable {other_var} specified in both nd_gaussian_dist and as separate distribution."
+                    )
+
+            if params["start"]["type"] == "cathode":
                 for var in nd_gaussian_dist_vars:
-                    if var in ['px', 'py', 'pz']:
-                        raise ValueError(f"Momentum variable {var} cannot be specified in nd_gaussian_dist for cathode start.")
+                    if var in ["px", "py", "pz"]:
+                        raise ValueError(
+                            f"Momentum variable {var} cannot be specified in nd_gaussian_dist for cathode start."
+                        )
 
         # Check consistency of transverse coordinate definitions
         if ("r_dist" in params) and ("x_dist" in params or "xy_dist" in params):
@@ -332,9 +344,7 @@ class Generator(Base):
 
         if "spin_polarization" in params:
             if params["species"] != "electron":
-                raise ValueError(
-                    "Polarization currently may only be set for electrons"
-                )
+                raise ValueError("Polarization currently may only be set for electrons")
 
     @property
     def fix_avg_and_stds(self):
@@ -372,7 +382,8 @@ class Generator(Base):
 
             vprint(f"Reading Distgen archive file {h5}", self.verbose > 0, 1, False)
 
-        # self.input = archive.read_input_h5(g['input'])
+        if "input" in g:
+            self.parse_input(archive.read_input_h5(g["input"]))
 
         if "particles" in g:
             self.particles = ParticleGroup(g["particles"])
@@ -404,11 +415,11 @@ class Generator(Base):
         archive.distgen_init(g)
 
         # Input
-        # archive.write_input_h5(g, self.input, name='input')
+        archive.write_input_h5(g, self.input, name="input")
 
         # Particles
         if self.particles:
-            self.particles.write(g, name="particles")
+            self.particles.write(g.create_group("particles"))
         return h5
 
     def get_dist_params(self, params):
@@ -464,7 +475,7 @@ class Generator(Base):
                 1,
                 True,
             )
-      
+
         if params["start"]["type"] == "time" and "t_dist" in params:
             raise ValueError("Error: t_dist should not be set for time start")
 
@@ -535,9 +546,7 @@ class Generator(Base):
         for ii, vii in enumerate(var_list[:-1]):
             viip1 = var_list[ii + 1]
             if (
-                np.array_equal(
-                    self.rands[vii].magnitude, self.rands[viip1].magnitude
-                )
+                np.array_equal(self.rands[vii].magnitude, self.rands[viip1].magnitude)
                 and n_particle != 1
             ):
                 raise ValueError(
@@ -652,18 +661,20 @@ class Generator(Base):
         )  # Get the relevant dist params, setting defaults as needed, and samples random number generator
 
         rand_variables = list(
-                dist_params.keys()
+            dist_params.keys()
         )  # All variables with distributions specified
 
         if "spin_polarization" in params:
             rand_variables = rand_variables + ["sz"]
 
-        if 'nd_gaussian' in rand_variables:
-            nd_gaussian_dist_vars = [p for p in dist_params["nd_gaussian"]['centroid'].keys()]
+        if "nd_gaussian" in rand_variables:
+            nd_gaussian_dist_vars = [
+                p for p in dist_params["nd_gaussian"]["centroid"].keys()
+            ]
             rand_variables = rand_variables + [v for v in nd_gaussian_dist_vars]
-            rand_variables.remove('nd_gaussian')
+            rand_variables.remove("nd_gaussian")
 
-        #print(rand_variables)
+        # print(rand_variables)
 
         self.get_rands(rand_variables)
 
@@ -881,27 +892,26 @@ class Generator(Base):
                 bdist["sy"] = Sp[1, :] * (hbar / 2)
                 bdist["sz"] = Sp[2, :] * (hbar / 2)
 
-        if 'nd_gaussian' in dist_params:
-
-            nd_params = dist_params['nd_gaussian']
-            nd_params['type'] = 'nd_gaussian'
-            vars = list( dist_params['nd_gaussian']['centroid'].keys() )
+        if "nd_gaussian" in dist_params:
+            nd_params = dist_params["nd_gaussian"]
+            nd_params["type"] = "nd_gaussian"
+            vars = list(dist_params["nd_gaussian"]["centroid"].keys())
 
             dist = get_dist(vars, nd_params, verbose=verbose)
-            nd_rands = {k:self.rands[k] for k in nd_params['centroid'].keys()}
+            nd_rands = {k: self.rands[k] for k in nd_params["centroid"].keys()}
 
             samples = dist.cdfinv(nd_rands)
 
-            for var in nd_params['centroid'].keys():
+            for var in nd_params["centroid"].keys():
                 bdist[var] = samples[var]
 
             dist_params.pop("nd_gaussian", None)
 
-            for k, v in nd_params['centroid'].items():
+            for k, v in nd_params["centroid"].items():
                 avgs.pop(k, None)
                 stds.pop(k, None)
 
-            #for k, v in dist.sigmas.items():
+            # for k, v in dist.sigmas.items():
             #    stds[k] = v
 
         # Do all other specified single coordinate dists
@@ -920,7 +930,6 @@ class Generator(Base):
                     avgs[x] = dist.avg()
 
                 stds[x] = dist.std()
-
 
             else:  # Someone may set sigma = 0 but have a non-zero avg
                 if "avg_" + x in dist_params[x]:

--- a/distgen/tests/test_archive.py
+++ b/distgen/tests/test_archive.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+import h5py
+import pytest
+
+from .. import Generator
+from .conftest import EXAMPLES_DATA_PATH
+
+
+@pytest.fixture(scope="module")
+def generator() -> Generator:
+    G = Generator(str(EXAMPLES_DATA_PATH / "gaussian.in.yaml"))
+    G["n_particle"] = 2000
+    G.run()
+    return G
+
+
+def _assert_roundtrip(original: Generator, reloaded: Generator) -> None:
+    # Input is fully restored
+    assert reloaded.input == original.input
+
+    # Particles are restored and re-runnable
+    reloaded.run()
+    assert len(reloaded.particles["x"]) == len(original.particles["x"])
+    assert reloaded["start:type"] == original["start:type"]
+
+
+def test_archive_roundtrip_to_filename(generator: Generator, tmp_path) -> None:
+    """Archive to a filename (internal h5py.File), reload, and re-run."""
+    fname = str(tmp_path / "archive.h5")
+    generator.archive(fname)
+
+    # Correct particle layout: particles/<species>, not particles/particles/<species>
+    with h5py.File(fname, "r") as f:
+        assert "input" in f
+        assert "particles" in f
+        assert "particles" not in f["particles"]
+
+    reloaded = Generator()
+    reloaded.load_archive(fname)
+    _assert_roundtrip(generator, reloaded)
+
+
+def test_archive_roundtrip_into_group(generator: Generator, tmp_path) -> None:
+    """Archive into an existing subgroup (the lume-astra pattern), reload, and re-run."""
+    fname = str(tmp_path / "archive_group.h5")
+    with h5py.File(fname, "w") as f:
+        generator.archive(f.create_group("distgen"))
+
+    reloaded = Generator()
+    reloaded.load_archive(fname)
+    _assert_roundtrip(generator, reloaded)
+
+
+def test_archive_skips_none_input_values(generator: Generator, tmp_path) -> None:
+    """None-valued input keys are dropped on write and treated as absent on read."""
+    fname = str(tmp_path / "archive_none.h5")
+    generator.archive(fname)
+
+    with h5py.File(fname, "r") as f:
+        assert not any(v is None for v in f["input"].attrs.values())
+
+
+def test_load_archive_without_input_group(generator: Generator, tmp_path) -> None:
+    """Legacy archives lacking an 'input' group still load without error."""
+    fname = str(tmp_path / "legacy.h5")
+    generator.archive(fname)
+
+    # Remove the input group to emulate a legacy archive
+    with h5py.File(fname, "a") as f:
+        del f["input"]
+
+    reloaded = Generator()
+    reloaded.load_archive(fname)
+    assert len(reloaded.particles["x"]) == len(generator.particles["x"])

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ name: distgen-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9
+  - python>=3.14
   - matplotlib-base
   - numpy
   - scipy

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ name: distgen-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.14
+  - python>=3.10
   - matplotlib-base
   - numpy
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: distgen
 channels:
   - conda-forge
 dependencies:
-  - python>=3.9
+  - python>=3.10
   - matplotlib-base
   - numpy
   - scipy


### PR DESCRIPTION
## Summary
Distgen `Generator` archives could not be fully reconstructed and re-run:

1. **Input was never stored** — the `write_input_h5` / `read_input_h5` calls in
   `Generator.archive` / `Generator.load_archive` had been commented out long ago
   because of an HDF5 write bug.
2. Once input archiving was re-enabled, loading particles failed with
   `KeyError: 'speciesType'` due to a **double-nested particle group** caused by an
   upstream `openPMD-beamphysics` API change.

This PR fixes both so a `Generator` can be archived, reloaded, and re-run end-to-end.

## Changes

### `distgen/archive.py`
`write_input_h5` now skips `None` values when writing the flattened input dict.

- **Why:** `self.input` contains `None` for unused sections (e.g. `output:type`,
  `transforms`). h5py cannot store Python `None` as an attribute and raised
  `TypeError: Object dtype dtype('O') has no native HDF5 equivalent`, which is the
  original reason the archiving lines were disabled.
- Absent keys read back as "missing", which distgen already treats the same as `None`,
  so the round-trip is lossless for these sections.

### `distgen/generator.py`
- **`archive()`**: re-enabled
  `archive.write_input_h5(g, self.input, name="input")`.
- **`load_archive()`**: re-enabled the input read, guarded for legacy archives that have
  no `input` group:
  ```python
  if "input" in g:
      self.parse_input(archive.read_input_h5(g["input"]))
  ```
  `parse_input(...)` is used (rather than assigning `self.input`) because `input` is a
  read-only property; `parse_input` correctly rebuilds the internal `_input` state.
- **`archive()` particle write**: changed
  `self.particles.write(g, name="particles")` to
  `self.particles.write(g.create_group("particles"))`.
  - **Why:** the current `openPMD-beamphysics` `ParticleGroup.write` auto-creates a
    `particles` group when given a `File`, and `write_pmd_bunch` then creates another
    group from `name=`, producing `particles/particles/electron`. The reader descended
    only one level and failed with `KeyError: 'speciesType'`. Writing into an
    explicitly-created group yields the correct `particles/<species>` layout for both the
    filename/`File` case and the existing-group case (e.g. lume-astra passing a subgroup).

### `environment.yml` / `environment-dev.yml`
Bumped the minimum supported Python from `python>=3.9` to `python>=3.10` in both env
files, matching `pyproject.toml`'s `requires-python = ">=3.10"` and the CI test matrix
(3.10–3.14).

- **Note:** `environment-dev.yml` must keep a *minimum* pin (`>=3.10`), not a fixed/high
  pin, because the CI workflow feeds it to `setup-miniconda` together with the matrix
  `python-version`. setup-miniconda appends `python=<matrix>` to the env file without
  removing the existing pin, so a `python>=3.14` line conflicts with e.g. `python=3.10`
  and the solve fails (`Could not solve for environment specs`). A `>=3.10` floor is
  satisfiable by every matrix version.

### `distgen/tests/test_archive.py` (new)
Adds coverage for archiving, which previously had none:
- `test_archive_roundtrip_to_filename` — archive to a filename, reload, re-run; asserts
  input equality, particle counts, and the correct `particles/<species>` layout.
- `test_archive_roundtrip_into_group` — archive into an existing subgroup (lume-astra
  pattern), reload, re-run.
- `test_archive_skips_none_input_values` — `None`-valued input keys are not written.
- `test_load_archive_without_input_group` — legacy archives without an `input` group
  still load.

## Verification
- Full round-trip (`archive` → `load_archive` → `run`) reproduces particle counts and
  `start:type`, with `Generator(read_back).input == G.input` (`input matches: True`),
  for both:
  - archiving to a filename (`File` handle), and
  - archiving into an existing subgroup (the lume-astra pattern).
- New `distgen/tests/test_archive.py` covers these cases (4 passed).
- Full test suite passes: `674 passed`.


## Downstream motivation (lume-astra)
`lume-astra`'s `archive_astra_with_distgen` calls `distgen_object.archive(g)`. Because
input was not stored, the `distgen` group was effectively empty and
`docs/examples/functional_astra_run.ipynb` could not reload the `Generator`
(`G._input is None` → `G['start:type']` raised). Re-enabling input archiving fixes that
example.

## Compatibility note
Archives written by this change require the current `openPMD-beamphysics` reader (the
particle nesting fix follows the upstream API change). Legacy archives without an `input`
group still load (input restore is guarded).

## Acknowledgements
This fix was developed with the assistance of GitHub Copilot (Claude), which helped
diagnose the `None`/HDF5 attribute bug and the `openPMD-beamphysics` particle group
double-nesting issue, and verified the archive round-trip end-to-end.

